### PR TITLE
Fixes #6 panic in some cases

### DIFF
--- a/ginmetrics/middleware.go
+++ b/ginmetrics/middleware.go
@@ -114,7 +114,10 @@ func (m *Monitor) ginMetricHandle(ctx *gin.Context, start time.Time) {
 	_ = m.GetMetric(metricURIRequestTotal).Inc([]string{ctx.FullPath(), r.Method, strconv.Itoa(w.Status())})
 
 	// set request body size
-	_ = m.GetMetric(metricRequestBody).Add(nil, float64(r.ContentLength))
+	// since r.ContentLength can be negative (in some occasions) guard the operation
+	if r.ContentLength >= 0 {
+		_ = m.GetMetric(metricRequestBody).Add(nil, float64(r.ContentLength))
+	}
 
 	// set slow request
 	latency := time.Since(start)


### PR DESCRIPTION
This fixes panic when ContentLength is negative (maybe a panic/error interrupts the creation of a body this staying at -1 in ContentLenght)