### PR TITLE
Fix error formatter in types for metric.Type

### DIFF
--- a/ginmetrics/types.go
+++ b/ginmetrics/types.go
@@ -113,7 +113,7 @@ func (m *Monitor) AddMetric(metric *Metric) error {
 			m.metrics[metric.Name] = metric
 		}
 	}
-	return errors.Errorf("metric type '%s' not existed.", metric.Type)
+	return errors.Errorf("metric type '%d' not existed.", metric.Type)
 }
 
 func counterHandler(metric *Metric) error {


### PR DESCRIPTION
metric.Type is int, so should use %d instead of %s. Otherwise, nogo check will throw an error.