### PR TITLE
Protect global monitor from race conditions

### DIFF
--- a/ginmetrics/types.go
+++ b/ginmetrics/types.go
@@ -3,6 +3,8 @@ package ginmetrics
 import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
+
+	"sync"
 )
 
 type MetricType int
@@ -19,8 +21,10 @@ const (
 )
 
 var (
+	once    sync.Once
+	monitor *Monitor
+
 	defaultDuration = []float64{0.1, 0.3, 1.2, 5, 10}
-	monitor         *Monitor
 
 	promTypeHandler = map[MetricType]func(metric *Metric) error{
 		Counter:   counterHandler,
@@ -41,14 +45,15 @@ type Monitor struct {
 // GetMonitor used to get global Monitor object,
 // this function returns a singleton object.
 func GetMonitor() *Monitor {
-	if monitor == nil {
+	once.Do(func() {
 		monitor = &Monitor{
 			metricPath:  defaultMetricPath,
 			slowTime:    defaultSlowTime,
 			reqDuration: defaultDuration,
 			metrics:     make(map[string]*Metric),
 		}
-	}
+	})
+
 	return monitor
 }
 

--- a/ginmetrics/types_test.go
+++ b/ginmetrics/types_test.go
@@ -1,0 +1,9 @@
+package ginmetrics
+
+import "testing"
+
+func TestSingletonRacing(t *testing.T) {
+	for i := 0; i < 10; i++ {
+		go GetMonitor()
+	}
+}


### PR DESCRIPTION
ensuring that the monitor is declared a single time by becoming atomic. This approach protects also against race conditions