### PR TITLE
remove piechart plugin as it is available as part of the core plugins

### DIFF
--- a/grafana/README.md
+++ b/grafana/README.md
@@ -1,5 +1,3 @@
 ## Manual 
 
-If you want to use this grafana.json. You should install pie plugin for Grafana:
-
-https://grafana.com/grafana/plugins/grafana-piechart-panel
+If you want to use this grafana.json. 

--- a/grafana/grafana.json
+++ b/grafana/grafana.json
@@ -501,7 +501,7 @@
       "timeFrom": null,
       "timeShift": null,
       "title": "Method",
-      "type": "grafana-piechart-panel",
+      "type": "piechart",
       "valueName": "current"
     },
     {
@@ -681,7 +681,7 @@
       "timeFrom": null,
       "timeShift": null,
       "title": "Code",
-      "type": "grafana-piechart-panel",
+      "type": "piechart",
       "valueName": "current"
     },
     {


### PR DESCRIPTION
Grafana 8.0 has the plugin installed as core. https://grafana.com/grafana/plugins/grafana-piechart-panel/