### PR TITLE
feat: try to get path from Request.URL when ctx.FullPath() is empty

### DIFF
--- a/ginmetrics/middleware.go
+++ b/ginmetrics/middleware.go
@@ -8,7 +8,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
-	"github.com/penglongli/gin-metrics/bloom"
+	"github.com/jiekun/gin-metrics/bloom"
 )
 
 var (
@@ -145,11 +145,11 @@ func (m *Monitor) ginMetricHandle(ctx *gin.Context, start time.Time) {
 	// set slow request
 	latency := time.Since(start)
 	if int32(latency.Seconds()) > m.slowTime {
-		_ = m.GetMetric(metricSlowRequest).Inc([]string{ctx.FullPath(), r.Method, strconv.Itoa(w.Status())})
+		_ = m.GetMetric(metricSlowRequest).Inc([]string{path, r.Method, strconv.Itoa(w.Status())})
 	}
 
 	// set request duration
-	_ = m.GetMetric(metricRequestDuration).Observe([]string{ctx.FullPath()}, latency.Seconds())
+	_ = m.GetMetric(metricRequestDuration).Observe([]string{path}, latency.Seconds())
 
 	// set response size
 	if w.Size() > 0 {

--- a/ginmetrics/middleware.go
+++ b/ginmetrics/middleware.go
@@ -8,7 +8,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
-	"github.com/jiekun/gin-metrics/bloom"
+	"github.com/penglongli/gin-metrics/bloom"
 )
 
 var (

--- a/ginmetrics/middleware.go
+++ b/ginmetrics/middleware.go
@@ -127,8 +127,14 @@ func (m *Monitor) ginMetricHandle(ctx *gin.Context, start time.Time) {
 		_ = m.GetMetric(metricRequestUVTotal).Inc(nil)
 	}
 
+	// get the request path (the best effort)
+	path := ctx.FullPath()
+	if path == "" && ctx.Request != nil && ctx.Request.URL != nil {
+		path = ctx.Request.URL.Path
+	}
+
 	// set uri request total
-	_ = m.GetMetric(metricURIRequestTotal).Inc([]string{ctx.FullPath(), r.Method, strconv.Itoa(w.Status())})
+	_ = m.GetMetric(metricURIRequestTotal).Inc([]string{path, r.Method, strconv.Itoa(w.Status())})
 
 	// set request body size
 	// since r.ContentLength can be negative (in some occasions) guard the operation


### PR DESCRIPTION
when defining route like:
```go
    svr.NoRoute(handler.ReverseProxyHandler)
```

`ctx.FullPath()` might be an empty string. It's still possible to get the path from ctx.Request.URL.Path.

This pull request fixed it with best effort pattern.