### PR TITLE
fix: initialize summary metrics to avoid nil dereference

### DIFF
--- a/ginmetrics/types.go
+++ b/ginmetrics/types.go
@@ -148,7 +148,7 @@ func summaryHandler(metric *Metric) error {
 	if len(metric.Objectives) == 0 {
 		return errors.Errorf("metric '%s' is summary type, cannot lose objectives param.", metric.Name)
 	}
-	prometheus.NewSummaryVec(
+	metric.vec = prometheus.NewSummaryVec(
 		prometheus.SummaryOpts{Name: metric.Name, Help: metric.Description, Objectives: metric.Objectives},
 		metric.Labels,
 	)


### PR DESCRIPTION
Fixes #42 by correctly initializing `metric.vec` in the `summaryHandler` function